### PR TITLE
fix(go-sdk): update example to work with v0.3.1

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/ethereum/go-ethereum v1.12.0
-	github.com/zksync-sdk/zksync2-go v0.3.0-beta.2
+	github.com/zksync-sdk/zksync2-go v0.3.1
 )
 
 require (

--- a/go/go.sum
+++ b/go/go.sum
@@ -380,8 +380,8 @@ github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPyS
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zksync-sdk/zksync2-go v0.3.0-beta.2 h1:K1xhR9cdwKSWjSydkG+uTmyk9vwcqC8nJsduIhb5cZk=
-github.com/zksync-sdk/zksync2-go v0.3.0-beta.2/go.mod h1:sdzmWj4WFXOff/O7FWyVuDpV01HtyotwI+TQsRnUNqo=
+github.com/zksync-sdk/zksync2-go v0.3.1 h1:jYCNU+zXo+cOBk3kSmw/iHXo5BVTgD/ZFQWR95FLe8c=
+github.com/zksync-sdk/zksync2-go v0.3.1/go.mod h1:sdzmWj4WFXOff/O7FWyVuDpV01HtyotwI+TQsRnUNqo=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
This version `v0.3.0-beta.2` does not exist now.