### PR TITLE
refactor(js): remove redundant ethProvider in Wallet initialization

### DIFF
--- a/js/src/02_transfer.ts
+++ b/js/src/02_transfer.ts
@@ -2,9 +2,8 @@ import { Provider, types, Wallet } from "zksync-ethers";
 import { ethers } from "ethers";
 
 const provider = Provider.getDefaultProvider(types.Network.Sepolia);
-const ethProvider = ethers.getDefaultProvider("sepolia");
 const PRIVATE_KEY = process.env.PRIVATE_KEY;
-const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
+const wallet = new Wallet(PRIVATE_KEY, provider);
 
 async function main() {
     const receiver = "0x81E9D85b65E9CC8618D85A1110e4b1DF63fA30d9";


### PR DESCRIPTION
# What :computer: 
* Remove redundant ethProvider in Wallet initialization, transfer example.

# Why :hand:
* Since the goal here is to transfer the funds from L2 to L2, there is no need for ETH provider which is L1.

# Evidence :camera:
https://github.com/zksync-sdk/zksync-ethers/blob/c5f67d6aa22bcab572af3f0d2a3fd80de77af0c9/src/wallet.ts#L1102-L1115